### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -5,6 +5,10 @@ on:
     types:
       - labeled
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   auto-merge:
     if: github.actor == 'dependabot[bot]'


### PR DESCRIPTION
Potential fix for [https://github.com/demianturner/writingBlog/security/code-scanning/2](https://github.com/demianturner/writingBlog/security/code-scanning/2)

To fix the problem, you should add a `permissions` block to the workflow file, either at the root level (to apply to all jobs) or at the job level (to apply only to the `auto-merge` job). The minimal required permissions for automerging Dependabot PRs are typically `contents: read` and `pull-requests: write`. This change should be made in `.github/workflows/auto-merge-dependabot.yml`, above the `jobs:` key (for workflow-wide) or inside the `auto-merge` job (for job-specific). No additional imports or definitions are needed; just the addition of the `permissions` block in the YAML file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
