### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/label-dependabot.yml
+++ b/.github/workflows/label-dependabot.yml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+  pull-requests: write
 name: Label Dependabot PRs
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/demianturner/writingBlog/security/code-scanning/1](https://github.com/demianturner/writingBlog/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow or the specific job to restrict the `GITHUB_TOKEN` to only the permissions required. In this case, the workflow only needs to add a label to a pull request, which requires `contents: read` and `pull-requests: write`. The best way to fix this is to add the following block at the top level of the workflow (after the `name` field and before `on:`), or at the job level (under `label:`). Adding it at the top level is preferred for clarity and to ensure all jobs in the workflow inherit the least privilege unless otherwise specified.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
